### PR TITLE
License change to EUPL-1.2 and MkDocs documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Deploy docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install MkDocs and dependencies
+        run: pip install mkdocs-material
+
+      - name: Build docs
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Thumbs.db
 
 # ACLI generated
 .cli/
+
+# MkDocs
+site/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,4 +59,6 @@ docs: update Python SDK quick start example
 
 ## Code of Conduct
 
+This project is licensed under the [EUPL-1.2](LICENSE).
+
 This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,287 @@
-MIT License
+                      EUROPEAN UNION PUBLIC LICENCE v. 1.2
+                      EUPL © the European Union 2007, 2016
 
-Copyright (c) 2026 ACLI Contributors
+This European Union Public Licence (the ‘EUPL’) applies to the Work (as defined
+below) which is provided under the terms of this Licence. Any use of the Work,
+other than as authorised under this Licence is prohibited (to the extent such
+use is covered by a right of the copyright holder of the Work).
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+The Work is provided under the terms of this Licence when the Licensor (as
+defined below) has placed the following notice immediately following the
+copyright notice for the Work:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+        Licensed under the EUPL
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+or has expressed by any other means his willingness to license under the EUPL.
+
+1. Definitions
+
+In this Licence, the following terms have the following meaning:
+
+- ‘The Licence’: this Licence.
+
+- ‘The Original Work’: the work or software distributed or communicated by the
+  Licensor under this Licence, available as Source Code and also as Executable
+  Code as the case may be.
+
+- ‘Derivative Works’: the works or software that could be created by the
+  Licensee, based upon the Original Work or modifications thereof. This Licence
+  does not define the extent of modification or dependence on the Original Work
+  required in order to classify a work as a Derivative Work; this extent is
+  determined by copyright law applicable in the country mentioned in Article 15.
+
+- ‘The Work’: the Original Work or its Derivative Works.
+
+- ‘The Source Code’: the human-readable form of the Work which is the most
+  convenient for people to study and modify.
+
+- ‘The Executable Code’: any code which has generally been compiled and which is
+  meant to be interpreted by a computer as a program.
+
+- ‘The Licensor’: the natural or legal person that distributes or communicates
+  the Work under the Licence.
+
+- ‘Contributor(s)’: any natural or legal person who modifies the Work under the
+  Licence, or otherwise contributes to the creation of a Derivative Work.
+
+- ‘The Licensee’ or ‘You’: any natural or legal person who makes any usage of
+  the Work under the terms of the Licence.
+
+- ‘Distribution’ or ‘Communication’: any act of selling, giving, lending,
+  renting, distributing, communicating, transmitting, or otherwise making
+  available, online or offline, copies of the Work or providing access to its
+  essential functionalities at the disposal of any other natural or legal
+  person.
+
+2. Scope of the rights granted by the Licence
+
+The Licensor hereby grants You a worldwide, royalty-free, non-exclusive,
+sublicensable licence to do the following, for the duration of copyright vested
+in the Original Work:
+
+- use the Work in any circumstance and for all usage,
+- reproduce the Work,
+- modify the Work, and make Derivative Works based upon the Work,
+- communicate to the public, including the right to make available or display
+  the Work or copies thereof to the public and perform publicly, as the case may
+  be, the Work,
+- distribute the Work or copies thereof,
+- lend and rent the Work or copies thereof,
+- sublicense rights in the Work or copies thereof.
+
+Those rights can be exercised on any media, supports and formats, whether now
+known or later invented, as far as the applicable law permits so.
+
+In the countries where moral rights apply, the Licensor waives his right to
+exercise his moral right to the extent allowed by law in order to make effective
+the licence of the economic rights here above listed.
+
+The Licensor grants to the Licensee royalty-free, non-exclusive usage rights to
+any patents held by the Licensor, to the extent necessary to make use of the
+rights granted on the Work under this Licence.
+
+3. Communication of the Source Code
+
+The Licensor may provide the Work either in its Source Code form, or as
+Executable Code. If the Work is provided as Executable Code, the Licensor
+provides in addition a machine-readable copy of the Source Code of the Work
+along with each copy of the Work that the Licensor distributes or indicates, in
+a notice following the copyright notice attached to the Work, a repository where
+the Source Code is easily and freely accessible for as long as the Licensor
+continues to distribute or communicate the Work.
+
+4. Limitations on copyright
+
+Nothing in this Licence is intended to deprive the Licensee of the benefits from
+any exception or limitation to the exclusive rights of the rights owners in the
+Work, of the exhaustion of those rights or of other applicable limitations
+thereto.
+
+5. Obligations of the Licensee
+
+The grant of the rights mentioned above is subject to some restrictions and
+obligations imposed on the Licensee. Those obligations are the following:
+
+Attribution right: The Licensee shall keep intact all copyright, patent or
+trademarks notices and all notices that refer to the Licence and to the
+disclaimer of warranties. The Licensee must include a copy of such notices and a
+copy of the Licence with every copy of the Work he/she distributes or
+communicates. The Licensee must cause any Derivative Work to carry prominent
+notices stating that the Work has been modified and the date of modification.
+
+Copyleft clause: If the Licensee distributes or communicates copies of the
+Original Works or Derivative Works, this Distribution or Communication will be
+done under the terms of this Licence or of a later version of this Licence
+unless the Original Work is expressly distributed only under this version of the
+Licence — for example by communicating ‘EUPL v. 1.2 only’. The Licensee
+(becoming Licensor) cannot offer or impose any additional terms or conditions on
+the Work or Derivative Work that alter or restrict the terms of the Licence.
+
+Compatibility clause: If the Licensee Distributes or Communicates Derivative
+Works or copies thereof based upon both the Work and another work licensed under
+a Compatible Licence, this Distribution or Communication can be done under the
+terms of this Compatible Licence. For the sake of this clause, ‘Compatible
+Licence’ refers to the licences listed in the appendix attached to this Licence.
+Should the Licensee's obligations under the Compatible Licence conflict with
+his/her obligations under this Licence, the obligations of the Compatible
+Licence shall prevail.
+
+Provision of Source Code: When distributing or communicating copies of the Work,
+the Licensee will provide a machine-readable copy of the Source Code or indicate
+a repository where this Source will be easily and freely available for as long
+as the Licensee continues to distribute or communicate the Work.
+
+Legal Protection: This Licence does not grant permission to use the trade names,
+trademarks, service marks, or names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the copyright notice.
+
+6. Chain of Authorship
+
+The original Licensor warrants that the copyright in the Original Work granted
+hereunder is owned by him/her or licensed to him/her and that he/she has the
+power and authority to grant the Licence.
+
+Each Contributor warrants that the copyright in the modifications he/she brings
+to the Work are owned by him/her or licensed to him/her and that he/she has the
+power and authority to grant the Licence.
+
+Each time You accept the Licence, the original Licensor and subsequent
+Contributors grant You a licence to their contributions to the Work, under the
+terms of this Licence.
+
+7. Disclaimer of Warranty
+
+The Work is a work in progress, which is continuously improved by numerous
+Contributors. It is not a finished work and may therefore contain defects or
+‘bugs’ inherent to this type of development.
+
+For the above reason, the Work is provided under the Licence on an ‘as is’ basis
+and without warranties of any kind concerning the Work, including without
+limitation merchantability, fitness for a particular purpose, absence of defects
+or errors, accuracy, non-infringement of intellectual property rights other than
+copyright as stated in Article 6 of this Licence.
+
+This disclaimer of warranty is an essential part of the Licence and a condition
+for the grant of any rights to the Work.
+
+8. Disclaimer of Liability
+
+Except in the cases of wilful misconduct or damages directly caused to natural
+persons, the Licensor will in no event be liable for any direct or indirect,
+material or moral, damages of any kind, arising out of the Licence or of the use
+of the Work, including without limitation, damages for loss of goodwill, work
+stoppage, computer failure or malfunction, loss of data or any commercial
+damage, even if the Licensor has been advised of the possibility of such damage.
+However, the Licensor will be liable under statutory product liability laws as
+far such laws apply to the Work.
+
+9. Additional agreements
+
+While distributing the Work, You may choose to conclude an additional agreement,
+defining obligations or services consistent with this Licence. However, if
+accepting obligations, You may act only on your own behalf and on your sole
+responsibility, not on behalf of the original Licensor or any other Contributor,
+and only if You agree to indemnify, defend, and hold each Contributor harmless
+for any liability incurred by, or claims asserted against such Contributor by
+the fact You have accepted any warranty or additional liability.
+
+10. Acceptance of the Licence
+
+The provisions of this Licence can be accepted by clicking on an icon ‘I agree’
+placed under the bottom of a window displaying the text of this Licence or by
+affirming consent in any other similar way, in accordance with the rules of
+applicable law. Clicking on that icon indicates your clear and irrevocable
+acceptance of this Licence and all of its terms and conditions.
+
+Similarly, you irrevocably accept this Licence and all of its terms and
+conditions by exercising any rights granted to You by Article 2 of this Licence,
+such as the use of the Work, the creation by You of a Derivative Work or the
+Distribution or Communication by You of the Work or copies thereof.
+
+11. Information to the public
+
+In case of any Distribution or Communication of the Work by means of electronic
+communication by You (for example, by offering to download the Work from a
+remote location) the distribution channel or media (for example, a website) must
+at least provide to the public the information requested by the applicable law
+regarding the Licensor, the Licence and the way it may be accessible, concluded,
+stored and reproduced by the Licensee.
+
+12. Termination of the Licence
+
+The Licence and the rights granted hereunder will terminate automatically upon
+any breach by the Licensee of the terms of the Licence.
+
+Such a termination will not terminate the licences of any person who has
+received the Work from the Licensee under the Licence, provided such persons
+remain in full compliance with the Licence.
+
+13. Miscellaneous
+
+Without prejudice of Article 9 above, the Licence represents the complete
+agreement between the Parties as to the Work.
+
+If any provision of the Licence is invalid or unenforceable under applicable
+law, this will not affect the validity or enforceability of the Licence as a
+whole. Such provision will be construed or reformed so as necessary to make it
+valid and enforceable.
+
+The European Commission may publish other linguistic versions or new versions of
+this Licence or updated versions of the Appendix, so far this is required and
+reasonable, without reducing the scope of the rights granted by the Licence. New
+versions of the Licence will be published with a unique version number.
+
+All linguistic versions of this Licence, approved by the European Commission,
+have identical value. Parties can take advantage of the linguistic version of
+their choice.
+
+14. Jurisdiction
+
+Without prejudice to specific agreement between parties,
+
+- any litigation resulting from the interpretation of this License, arising
+  between the European Union institutions, bodies, offices or agencies, as a
+  Licensor, and any Licensee, will be subject to the jurisdiction of the Court
+  of Justice of the European Union, as laid down in article 272 of the Treaty on
+  the Functioning of the European Union,
+
+- any litigation arising between other parties and resulting from the
+  interpretation of this License, will be subject to the exclusive jurisdiction
+  of the competent court where the Licensor resides or conducts its primary
+  business.
+
+15. Applicable Law
+
+Without prejudice to specific agreement between parties,
+
+- this Licence shall be governed by the law of the European Union Member State
+  where the Licensor has his seat, resides or has his registered office,
+
+- this licence shall be governed by Belgian law if the Licensor has no seat,
+  residence or registered office inside a European Union Member State.
+
+Appendix
+
+‘Compatible Licences’ according to Article 5 EUPL are:
+
+- GNU General Public License (GPL) v. 2, v. 3
+- GNU Affero General Public License (AGPL) v. 3
+- Open Software License (OSL) v. 2.1, v. 3.0
+- Eclipse Public License (EPL) v. 1.0
+- CeCILL v. 2.0, v. 2.1
+- Mozilla Public Licence (MPL) v. 2
+- GNU Lesser General Public Licence (LGPL) v. 2.1, v. 3
+- Creative Commons Attribution-ShareAlike v. 3.0 Unported (CC BY-SA 3.0) for
+  works other than software
+- European Union Public Licence (EUPL) v. 1.1, v. 1.2
+- Québec Free and Open-Source Licence — Reciprocity (LiLiQ-R) or Strong
+  Reciprocity (LiLiQ-R+).
+
+The European Commission may update this Appendix to later versions of the above
+licences without producing a new version of the EUPL, as long as they provide
+the rights granted in Article 2 of this Licence and protect the covered Source
+Code from exclusive appropriation.
+
+All other changes or additions to this Appendix require the production of a new
+EUPL version.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,62 @@
+# Contributing
+
+Thank you for your interest in contributing to ACLI!
+
+## Getting started
+
+1. Fork the repository
+2. Clone your fork
+3. Create a feature branch from `develop`
+4. Make your changes
+5. Submit a pull request targeting `develop`
+
+## Development setup
+
+### Python SDK
+
+```bash
+cd sdks/python
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+## Quality checks
+
+All checks must pass before submitting a PR:
+
+```bash
+ruff check src/ tests/          # Linting
+ruff format --check src/ tests/ # Formatting
+mypy src/                       # Type checking
+pytest                          # Tests (90% coverage minimum)
+```
+
+## Branch strategy
+
+| Branch | Purpose |
+|--------|---------|
+| `main` | Stable releases, protected |
+| `develop` | Integration branch for PRs |
+| `feat/*` | Feature branches |
+| `fix/*` | Bug fix branches |
+
+## Pull request process
+
+1. Branch from `develop` with a descriptive name
+2. Keep PRs focused — one feature or fix per PR
+3. Ensure all CI checks pass
+4. Update documentation if you change public APIs
+5. Add tests for new functionality
+
+## Commit messages
+
+```
+feat: add acli validate command
+fix: correct exit code for dry-run mode
+docs: update Python SDK quick start
+```
+
+## License
+
+By contributing, you agree that your contributions will be licensed under [EUPL-1.2](https://github.com/alpibrusl/acli/blob/main/LICENSE).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,81 @@
+# ACLI — Agent-friendly CLI
+
+**Build CLI tools that AI agents can discover, learn, and use autonomously.**
+
+ACLI is a lightweight specification for designing CLI tools that agents can bootstrap at runtime — without pre-loaded schemas or external tool registries. The core insight: a well-designed CLI is self-documenting enough that an agent can learn it on demand by running `<tool> --help`.
+
+## How it works
+
+```
+MCP           → schema defined externally, injected at agent startup
+SKILLS.md     → instructions written by humans, loaded into context
+<cli> --help  → tool teaches itself to the agent on demand
+```
+
+ACLI formalises what "well-designed" means in an agentic context, targeting the third stage.
+
+## Key principles
+
+1. **Progressive Discovery** — learn the full capability surface incrementally, starting from `--help`
+2. **Machine-readable by default** — structured output (JSON) is a first-class citizen
+3. **Fail informatively** — errors teach, not just reject
+4. **Safe exploration** — reason about actions before committing via `--dry-run`
+5. **Consistent contracts** — exit codes, output formats, and error shapes are predictable
+
+## Quick start
+
+### Install the Python SDK
+
+```bash
+pip install acli-spec
+```
+
+### Build your first ACLI tool
+
+```python
+from pathlib import Path
+from acli import ACLIApp, acli_command, OutputFormat
+import typer
+
+app = ACLIApp(name="myapp", version="1.0.0")
+
+@app.command()
+@acli_command(
+    examples=[
+        ("Run a task", "myapp run --file task.yaml"),
+        ("Dry-run a task", "myapp run --file task.yaml --dry-run"),
+    ],
+    idempotent=False,
+)
+def run(
+    file: Path = typer.Option(..., help="Path to task file. type:path"),
+    dry_run: bool = typer.Option(False, help="Preview without executing."),
+    output: OutputFormat = typer.Option(OutputFormat.text),
+) -> None:
+    """Execute a task from a YAML file."""
+    ...
+
+if __name__ == "__main__":
+    app.run()
+```
+
+You automatically get:
+
+- `myapp introspect` — full command tree as JSON
+- `myapp version` — semver output with `--output json` support
+- `.cli/` folder with README, examples, and schemas
+- JSON error envelopes with actionable hints
+- Semantic exit codes (0–9)
+
+## SDKs
+
+| Language | Status | Package |
+|----------|--------|---------|
+| Python   | ✅ Available | `pip install acli-spec` |
+| Go       | 🔜 Planned  | — |
+| Rust     | 🔜 Planned  | — |
+| Node.js  | 🔜 Planned  | — |
+
+## License
+
+[EUPL-1.2](https://github.com/alpibrusl/acli/blob/main/LICENSE)

--- a/docs/python-sdk/app.md
+++ b/docs/python-sdk/app.md
@@ -1,0 +1,84 @@
+# ACLIApp
+
+`ACLIApp` is the main application class. It wraps `typer.Typer` and automatically enforces ACLI spec compliance.
+
+## Constructor
+
+```python
+from acli import ACLIApp
+
+app = ACLIApp(
+    name="mytool",       # Tool name (used in version output and introspect)
+    version="1.0.0",     # Semver version string
+    cli_dir=None,        # Optional: override .cli/ folder location
+)
+```
+
+## Registering commands
+
+Use `@app.command()` just like Typer, combined with [`@acli_command`](commands.md) for ACLI metadata:
+
+```python
+@app.command()
+@acli_command(
+    examples=[("Example 1", "mytool do --flag"), ("Example 2", "mytool do --other")],
+    idempotent=True,
+)
+def do(
+    flag: str = typer.Option(..., help="A required flag. type:string"),
+) -> None:
+    """Do something."""
+    ...
+```
+
+## Adding sub-groups
+
+```python
+import typer
+
+sub = typer.Typer(help="Manage configs")
+
+@sub.command()
+def show() -> None:
+    """Show current config."""
+    ...
+
+app.add_typer(sub, name="config")
+```
+
+## Running the app
+
+```python
+app.run()
+```
+
+This wraps `typer()` with ACLI error handling:
+
+- `ACLIError` subclasses are caught and emitted as JSON error envelopes with the correct exit code
+- Unexpected exceptions are caught and emitted as `GENERAL_ERROR` (exit code 1)
+- `SystemExit` is re-raised as-is
+
+## Built-in commands
+
+### `introspect`
+
+```bash
+mytool introspect                    # Full command tree as JSON
+mytool introspect --acli-version     # Just the ACLI spec version
+```
+
+Also updates `.cli/` if out of date.
+
+### `version`
+
+```bash
+mytool version                       # Human-readable
+mytool version --output json         # JSON envelope
+```
+
+## Accessing internals
+
+```python
+app.typer_app          # The underlying typer.Typer instance
+app.get_command_tree() # Build the introspection tree as a dict
+```

--- a/docs/python-sdk/commands.md
+++ b/docs/python-sdk/commands.md
@@ -1,0 +1,52 @@
+# Commands
+
+## `@acli_command` decorator
+
+Attaches ACLI metadata to a Typer command function.
+
+```python
+from acli import acli_command
+
+@app.command()
+@acli_command(
+    examples=[
+        ("Run basic", "tool run --file a.yaml"),
+        ("Run with env", "tool run --file a.yaml --env prod"),
+    ],
+    idempotent=False,
+    see_also=["status", "logs"],
+)
+def run(...) -> None:
+    """Execute a pipeline."""
+    ...
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `examples` | `list[tuple[str, str]]` | Yes | `(description, invocation)` pairs. Minimum 2 per spec. |
+| `idempotent` | `bool \| "conditional"` | No | Whether the command is safe to retry. Default: `False`. |
+| `see_also` | `list[str]` | No | Related command names for the SEE ALSO section. |
+
+### Validation
+
+The decorator raises `ValueError` at import time if:
+
+- Fewer than 2 examples are provided
+- `idempotent` is a string other than `"conditional"`
+
+## CommandMeta
+
+The decorator stores a frozen `CommandMeta` dataclass on the function:
+
+```python
+from acli.command import ACLI_META_ATTR, CommandMeta
+
+meta: CommandMeta = getattr(my_func, ACLI_META_ATTR)
+meta.examples      # tuple of CommandExample(description, invocation)
+meta.idempotent    # True, False, or "conditional"
+meta.see_also      # tuple of command name strings
+```
+
+Both `CommandMeta` and `CommandExample` are frozen dataclasses — immutable after creation.

--- a/docs/python-sdk/errors.md
+++ b/docs/python-sdk/errors.md
@@ -1,0 +1,80 @@
+# Errors
+
+## Error hierarchy
+
+All ACLI errors extend `ACLIError`, which maps to a semantic exit code:
+
+```python
+from acli import ACLIError, InvalidArgsError, NotFoundError, ConflictError, PreconditionError
+
+raise InvalidArgsError(
+    "Missing required argument: --pipeline",
+    hint="Run `noether run --help` to see usage",
+    docs=".cli/examples/run.sh",
+)
+```
+
+| Error class | Exit code | When to use |
+|-------------|-----------|-------------|
+| `ACLIError` | `GENERAL_ERROR` (1) | Base class, generic errors |
+| `InvalidArgsError` | `INVALID_ARGS` (2) | Wrong arguments or flags |
+| `NotFoundError` | `NOT_FOUND` (3) | Resource doesn't exist |
+| `ConflictError` | `CONFLICT` (5) | State conflict (already exists, locked) |
+| `PreconditionError` | `PRECONDITION_FAILED` (8) | Required state not met |
+
+### Common fields
+
+All error classes accept:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `message` | `str` | What went wrong (positional) |
+| `hint` | `str \| None` | How to fix it |
+| `docs` | `str \| None` | Reference to example or docs |
+
+## Automatic error handling
+
+When using `ACLIApp.run()`, errors are automatically caught and converted to JSON error envelopes:
+
+```python
+app = ACLIApp(name="mytool", version="1.0.0")
+
+@app.command()
+def do_thing() -> None:
+    raise InvalidArgsError("Missing --file", hint="Provide a YAML file path")
+
+# Output:
+# {"ok": false, "error": {"code": "INVALID_ARGS", "message": "Missing --file", "hint": "..."}, ...}
+# Exit code: 2
+```
+
+## Flag suggestions
+
+Use `suggest_flag` to provide typo corrections per spec §4.1:
+
+```python
+from acli import suggest_flag
+
+suggestion = suggest_flag("--pipline", ["--pipeline", "--env", "--dry-run"])
+# Returns: "--pipeline"
+
+suggestion = suggest_flag("--zzz", ["--pipeline", "--env"])
+# Returns: None
+```
+
+## ExitCode enum
+
+```python
+from acli import ExitCode
+
+ExitCode.SUCCESS            # 0
+ExitCode.GENERAL_ERROR      # 1
+ExitCode.INVALID_ARGS       # 2
+ExitCode.NOT_FOUND          # 3
+ExitCode.PERMISSION_DENIED  # 4
+ExitCode.CONFLICT           # 5
+ExitCode.TIMEOUT            # 6
+ExitCode.UPSTREAM_ERROR     # 7
+ExitCode.PRECONDITION_FAILED # 8
+ExitCode.DRY_RUN            # 9
+```

--- a/docs/python-sdk/index.md
+++ b/docs/python-sdk/index.md
@@ -1,0 +1,71 @@
+# Python SDK — Getting Started
+
+The `acli-spec` package wraps [Typer](https://typer.tiangolo.com/) to automatically enforce the ACLI specification.
+
+## Installation
+
+```bash
+pip install acli-spec
+```
+
+For development:
+
+```bash
+git clone https://github.com/alpibrusl/acli.git
+cd acli/sdks/python
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+## Minimal example
+
+```python
+from pathlib import Path
+from acli import ACLIApp, acli_command, OutputFormat
+import typer
+
+app = ACLIApp(name="noether", version="1.0.0")
+
+@app.command()
+@acli_command(
+    examples=[
+        ("Run a pipeline in staging", "noether run --pipeline ./sprint.yaml --env staging"),
+        ("Dry-run a pipeline", "noether run --pipeline ./sprint.yaml --dry-run"),
+    ],
+    idempotent=False,
+)
+def run(
+    pipeline: Path = typer.Option(..., help="Path to Lagrange YAML pipeline file. type:path"),
+    env: str = typer.Option("dev", help="Target environment. type:enum[dev|staging|prod]"),
+    dry_run: bool = typer.Option(False, help="Describe actions without executing."),
+    output: OutputFormat = typer.Option(OutputFormat.text),
+) -> None:
+    """Execute a pipeline from a Lagrange YAML file."""
+    from acli import emit, success_envelope
+
+    data = {"pipeline": str(pipeline), "env": env, "status": "completed"}
+    emit(success_envelope("run", data, version="1.0.0"), output)
+
+if __name__ == "__main__":
+    app.run()
+```
+
+## What you get automatically
+
+When you create an `ACLIApp`, the SDK automatically:
+
+- Registers an `introspect` command that outputs the full command tree as JSON
+- Registers a `version` command with `--output json` support
+- Generates and maintains the `.cli/` folder on introspect/version calls
+- Catches `ACLIError` exceptions and emits JSON error envelopes
+- Catches unexpected exceptions with a generic error envelope
+
+## Running checks
+
+```bash
+ruff check src/ tests/          # Lint
+ruff format --check src/ tests/ # Format check
+mypy src/                       # Type check
+pytest                          # Tests (90% coverage minimum)
+```

--- a/docs/python-sdk/introspection.md
+++ b/docs/python-sdk/introspection.md
@@ -1,0 +1,74 @@
+# Introspection
+
+## Command tree
+
+`build_command_tree` extracts the full command tree from a Typer app via reflection:
+
+```python
+from acli.introspect import build_command_tree
+
+tree = build_command_tree(app.typer_app, "noether", "1.0.0")
+```
+
+The returned dict follows the spec §1.2 format:
+
+```json
+{
+  "name": "noether",
+  "version": "1.0.0",
+  "acli_version": "0.1.0",
+  "commands": [
+    {
+      "name": "run",
+      "description": "Execute a pipeline from a YAML file.",
+      "arguments": [],
+      "options": [
+        {"name": "pipeline", "type": "Path", "description": "..."},
+        {"name": "env", "type": "string", "description": "...", "default": "dev"}
+      ],
+      "subcommands": [],
+      "idempotent": false,
+      "examples": [
+        {"description": "Run in staging", "invocation": "noether run --pipeline x.yaml --env staging"}
+      ],
+      "see_also": ["status"]
+    }
+  ]
+}
+```
+
+Options, arguments, types, and defaults are all extracted automatically from the function signature and type hints.
+
+## `.cli/` folder generation
+
+```python
+from acli.cli_folder import generate_cli_folder, needs_update
+
+tree = app.get_command_tree()
+
+if needs_update(tree, target_dir=Path(".")):
+    cli_dir = generate_cli_folder(tree, target_dir=Path("."))
+```
+
+### Generated structure
+
+```
+.cli/
+  commands.json       # Full command tree (same as introspect output)
+  README.md           # Auto-generated overview with command list
+  changelog.md        # Created once, never overwritten
+  examples/
+    run.sh            # One script per command with examples
+  schemas/            # Reserved for JSON schemas
+```
+
+!!! note
+    `changelog.md` is only created if it doesn't exist. Manual edits are preserved across regeneration.
+
+### Checking for updates
+
+```python
+needs_update(tree, target_dir)  # True if .cli/commands.json differs from tree
+```
+
+This is called automatically by the built-in `introspect` and `version` commands.

--- a/docs/python-sdk/output.md
+++ b/docs/python-sdk/output.md
@@ -1,0 +1,81 @@
+# Output & Envelopes
+
+## OutputFormat
+
+```python
+from acli import OutputFormat
+
+OutputFormat.text   # Human-readable, coloured
+OutputFormat.json   # Strict JSON envelope
+OutputFormat.table  # ASCII table
+```
+
+Use as a Typer option in your commands:
+
+```python
+output: OutputFormat = typer.Option(OutputFormat.text, help="Output format.")
+```
+
+## Building envelopes
+
+### Success
+
+```python
+from acli import success_envelope
+
+envelope = success_envelope(
+    "run",                              # command name
+    {"result": "ok", "items": 42},      # data payload
+    version="1.0.0",
+    start_time=start,                   # optional: for duration_ms calculation
+)
+# {"ok": true, "command": "run", "data": {...}, "meta": {"duration_ms": ..., "version": "1.0.0"}}
+```
+
+### Dry-run success
+
+```python
+envelope = success_envelope(
+    "deploy",
+    {},
+    version="1.0.0",
+    dry_run=True,
+    planned_actions=[
+        {"action": "create", "target": "staging", "reversible": True},
+    ],
+)
+# {"ok": true, "command": "deploy", "dry_run": true, "planned_actions": [...], "meta": {...}}
+```
+
+When `dry_run=True`, the `data` key is omitted and `planned_actions` is used instead.
+
+### Error
+
+```python
+from acli import error_envelope
+
+envelope = error_envelope(
+    "run",
+    code="INVALID_ARGS",
+    message="Missing required argument: --pipeline",
+    hint="Run `noether run --help` to see usage",
+    docs=".cli/examples/run.sh",
+    version="1.0.0",
+)
+```
+
+## Emitting output
+
+```python
+from acli import emit
+
+emit(envelope, OutputFormat.json)   # JSON to stdout
+emit(envelope, OutputFormat.text)   # Human-readable (errors go to stderr)
+emit(envelope, OutputFormat.table)  # ASCII table
+```
+
+The `emit` function handles format-specific rendering:
+
+- **JSON**: `json.dump` with 2-space indent to stdout
+- **Text**: key-value pairs for success, formatted error block for errors (to stderr)
+- **Table**: column-aligned ASCII table for list data, key-value for dicts

--- a/docs/spec/compliance.md
+++ b/docs/spec/compliance.md
@@ -1,0 +1,22 @@
+# Compliance Checklist
+
+Use `acli validate` to check compliance automatically.
+
+## Requirements
+
+| # | Requirement | Level |
+|---|-------------|-------|
+| 1 | `--help` includes USAGE, DESCRIPTION, ARGUMENTS, OPTIONS, EXAMPLES, SEE ALSO | MUST |
+| 2 | Every argument has type annotation | MUST |
+| 3 | At least 2 concrete examples per command | MUST |
+| 4 | `introspect` command outputs full command tree as JSON | MUST |
+| 5 | `.cli/` folder generated and kept up to date | MUST |
+| 6 | `--output json\|text\|table` supported on all commands | MUST |
+| 7 | JSON error envelope used when `--output json` | MUST |
+| 8 | Semantic exit codes (0–9) used | MUST |
+| 9 | Error messages include correction hint and example pointer | MUST |
+| 10 | `--dry-run` on all state-modifying commands | MUST |
+| 11 | `--version` outputs semver-parseable format | MUST |
+| 12 | Idempotency declared per command | SHOULD |
+| 13 | NDJSON streaming for long-running commands | SHOULD |
+| 14 | `.cli/schemas/` contains JSON schemas for complex types | MAY |

--- a/docs/spec/discovery.md
+++ b/docs/spec/discovery.md
@@ -1,0 +1,92 @@
+# Progressive Discovery
+
+An agent should be able to learn the full capability surface of a tool incrementally, starting from `--help`.
+
+## `--help` structure
+
+Every command and subcommand **MUST** expose `--help` with these sections, in order:
+
+```
+<one-line description>
+
+USAGE:
+  <tool> <command> [OPTIONS] [ARGS]
+
+DESCRIPTION:
+  <2–5 line explanation of what this command does and when to use it>
+
+ARGUMENTS:
+  <name>    <type>    <required|optional>    <description>
+
+OPTIONS:
+  --option    <type>    <description>    [default: <value>]
+
+EXAMPLES:
+  # <intent description>
+  <tool> <command> <concrete invocation>
+
+  # <second example with different case>
+  <tool> <command> <concrete invocation>
+
+SEE ALSO:
+  <related subcommand>, <related subcommand>
+```
+
+### Rules
+
+- Descriptions must be written for an agent that has **no prior context**
+- Every argument and option must have a type annotation (`string`, `int`, `bool`, `enum[a|b|c]`, `path`)
+- At least **two examples** per command, with concrete invocations (no `<placeholder>`)
+- `SEE ALSO` must list related commands by name
+
+## Introspection command
+
+Every ACLI tool **MUST** expose:
+
+```bash
+<tool> introspect
+```
+
+This outputs the full command tree as JSON:
+
+```json
+{
+  "name": "noether",
+  "version": "1.2.0",
+  "acli_version": "0.1.0",
+  "commands": [
+    {
+      "name": "run",
+      "description": "Execute a pipeline from a Lagrange YAML file",
+      "arguments": [...],
+      "options": [...],
+      "subcommands": []
+    }
+  ]
+}
+```
+
+Agents should prefer `introspect` for initial capability mapping and `--help` for contextual guidance on a specific command.
+
+## `.cli/` reference folder
+
+Every ACLI tool **MUST** maintain a `.cli/` folder at the project root:
+
+```
+.cli/
+  README.md          # human-readable overview
+  commands.json      # same output as introspect
+  examples/
+    <command>.sh     # runnable example scripts per command
+  schemas/
+    <type>.json      # JSON schemas for complex types
+  changelog.md       # recent changes agents should be aware of
+```
+
+The `.cli/` folder is the **persistent knowledge base** for agents. It allows orientation without executing the tool, and survives context resets.
+
+### Update rules
+
+- Updated automatically on `<tool> --version` or `<tool> introspect`
+- Never requires elevated permissions to write
+- Safe to commit to version control

--- a/docs/spec/dry-run.md
+++ b/docs/spec/dry-run.md
@@ -1,0 +1,53 @@
+# Dry-run & Idempotency
+
+## Dry-run mode
+
+Every command that **modifies state** MUST support:
+
+```
+--dry-run    bool    Describe what would happen without executing    [default: false]
+```
+
+### Dry-run output requirements
+
+- Describe each action that would be taken
+- Include the exact parameters that would be used
+- Emit exit code `9` (`DRY_RUN`)
+- Respect `--output json`
+
+### Example output
+
+```json
+{
+  "ok": true,
+  "command": "deploy",
+  "dry_run": true,
+  "planned_actions": [
+    { "action": "create_namespace", "target": "staging", "reversible": true },
+    { "action": "apply_manifest", "target": "./k8s/deploy.yaml", "reversible": true }
+  ],
+  "meta": { "duration_ms": 12, "version": "1.2.0" }
+}
+```
+
+The `reversible` field helps agents assess risk before confirming execution.
+
+## Idempotency
+
+Commands **MUST** declare their idempotency in `--help` and in `commands.json`:
+
+```json
+{
+  "name": "apply",
+  "idempotent": true,
+  "description": "Apply configuration. Safe to run multiple times."
+}
+```
+
+| Value | Meaning |
+|-------|---------|
+| `true` | Running N times produces same result as running once |
+| `false` | Each run has side effects |
+| `"conditional"` | Idempotent if `--force` is not passed |
+
+Agents use this to determine whether to retry on ambiguous failure — an idempotent command can be safely retried, while a non-idempotent one requires confirmation.

--- a/docs/spec/errors.md
+++ b/docs/spec/errors.md
@@ -1,0 +1,58 @@
+# Error Design
+
+## Actionability requirement
+
+Every error message **MUST** be actionable. The test: *can an agent read the error and know exactly what to do next without any external context?*
+
+### Forbidden patterns
+
+- `"Error: invalid input"` — no specifics
+- `"Something went wrong"` — not actionable
+- `"See documentation"` — no link provided
+
+## Syntax error feedback
+
+When an agent provides incorrect syntax, the error **MUST**:
+
+1. State exactly what was wrong
+2. Suggest the correct form
+3. Point to a runnable example
+4. Include the relevant `--help` pointer
+
+### Example
+
+```
+Error [INVALID_ARGS]: Unknown flag '--pipline'
+  Did you mean: --pipeline?
+
+  Usage: noether run --pipeline <path> [--env <name>]
+
+  Example:
+    noether run --pipeline ./sprint.yaml --env staging
+
+  See full usage: noether run --help
+  Reference:      .cli/examples/run.sh
+```
+
+## JSON error format
+
+When `--output json` is active, errors use the standard envelope:
+
+```json
+{
+  "ok": false,
+  "command": "run",
+  "error": {
+    "code": "INVALID_ARGS",
+    "message": "Unknown flag '--pipline'",
+    "hint": "Did you mean: --pipeline? Run `noether run --help`",
+    "docs": ".cli/examples/run.sh"
+  },
+  "meta": {
+    "duration_ms": 3,
+    "version": "1.2.0"
+  }
+}
+```
+
+The `code` field maps directly to the [semantic exit codes](exit-codes.md), enabling programmatic error handling.

--- a/docs/spec/exit-codes.md
+++ b/docs/spec/exit-codes.md
@@ -1,0 +1,26 @@
+# Exit Codes
+
+ACLI tools **MUST** use semantic exit codes. Generic `0`/`1` is not sufficient for agentic retry logic.
+
+## Standard exit codes
+
+| Code | Name | Meaning | Agent action |
+|------|------|---------|--------------|
+| `0` | `SUCCESS` | Command completed successfully | Proceed |
+| `1` | `GENERAL_ERROR` | Unclassified error | Inspect stderr |
+| `2` | `INVALID_ARGS` | Wrong arguments or flags | Correct and retry |
+| `3` | `NOT_FOUND` | Resource does not exist | Check inputs |
+| `4` | `PERMISSION_DENIED` | Insufficient permissions | Escalate or skip |
+| `5` | `CONFLICT` | State conflict (already exists, locked) | Resolve conflict |
+| `6` | `TIMEOUT` | Operation timed out | Retry with backoff |
+| `7` | `UPSTREAM_ERROR` | External dependency failed | Retry or skip |
+| `8` | `PRECONDITION_FAILED` | Required state not met | Fix precondition first |
+| `9` | `DRY_RUN` | Dry-run completed, no changes made | Review and confirm |
+
+## Tool-specific codes
+
+Exit codes `10–63` are reserved for tool-specific codes, which **MUST** be documented in `.cli/README.md`.
+
+## Why this matters
+
+Agents use exit codes to decide their next action without parsing error messages. A `TIMEOUT` (6) triggers a retry with backoff, while `INVALID_ARGS` (2) triggers argument correction. This structured feedback loop enables autonomous recovery.

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -1,0 +1,26 @@
+# ACLI Specification
+
+> Version 0.1.0 · Draft
+
+The ACLI specification defines how CLI tools should be designed so that AI agents can discover, learn, and use them autonomously at runtime.
+
+## Sections
+
+| Section | What it covers |
+|---------|---------------|
+| [Progressive Discovery](discovery.md) | `--help` structure, `introspect` command, `.cli/` folder |
+| [Output Contracts](output.md) | `--output` flag, JSON envelope, streaming |
+| [Exit Codes](exit-codes.md) | Semantic exit codes 0–9 |
+| [Error Design](errors.md) | Actionable errors, typo suggestions |
+| [Dry-run & Idempotency](dry-run.md) | `--dry-run` mode, idempotency declaration |
+| [Compliance Checklist](compliance.md) | Full requirements table |
+
+## Evolution of agent tool integration
+
+```
+MCP           → schema defined externally, injected at agent startup
+SKILLS.md     → instructions written by humans, loaded into context
+<cli> --help  → tool teaches itself to the agent on demand (Progressive Skills)
+```
+
+ACLI targets the third stage — tools that are self-describing enough for agents to use without prior configuration.

--- a/docs/spec/output.md
+++ b/docs/spec/output.md
@@ -1,0 +1,67 @@
+# Output Contracts
+
+## Format flag
+
+Every command that produces output **MUST** support:
+
+```
+--output <format>    enum[text|json|table]    Output format    [default: text]
+```
+
+### Behaviour by format
+
+| Format | Use case | Rules |
+|--------|----------|-------|
+| `text` | Human reading | Coloured, formatted, may use unicode |
+| `json` | Agent consumption | Strict JSON, no decorations, to stdout |
+| `table` | Tabular data | ASCII-safe, parseable by column |
+
+!!! warning "Critical"
+    `--output json` **MUST** apply to both success and error responses. An agent that passes `--output json` must never receive unstructured text on stderr.
+
+## JSON envelope
+
+All JSON output **MUST** follow this envelope:
+
+### Success
+
+```json
+{
+  "ok": true,
+  "command": "run",
+  "data": { ... },
+  "meta": {
+    "duration_ms": 142,
+    "version": "1.2.0"
+  }
+}
+```
+
+### Error
+
+```json
+{
+  "ok": false,
+  "command": "run",
+  "error": {
+    "code": "INVALID_ARGS",
+    "message": "Missing required argument: --pipeline",
+    "hint": "Run `noether run --help` to see usage",
+    "docs": ".cli/examples/run.sh"
+  },
+  "meta": {
+    "duration_ms": 3,
+    "version": "1.2.0"
+  }
+}
+```
+
+## Streaming output
+
+For long-running commands, JSON streaming **MUST** use newline-delimited JSON (NDJSON):
+
+```
+{"type":"progress","step":"validate","status":"ok"}
+{"type":"progress","step":"execute","status":"running"}
+{"type":"result","ok":true,"data":{...}}
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,74 @@
+site_name: ACLI
+site_description: Agent-friendly CLI specification and SDKs
+site_url: https://alpibrusl.github.io/acli
+repo_url: https://github.com/alpibrusl/acli
+repo_name: alpibrusl/acli
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+    - search.suggest
+    - search.highlight
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.snippets
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Specification:
+      - Overview: spec/index.md
+      - Progressive Discovery: spec/discovery.md
+      - Output Contracts: spec/output.md
+      - Exit Codes: spec/exit-codes.md
+      - Error Design: spec/errors.md
+      - Dry-run & Idempotency: spec/dry-run.md
+      - Compliance Checklist: spec/compliance.md
+  - Python SDK:
+      - Getting Started: python-sdk/index.md
+      - ACLIApp: python-sdk/app.md
+      - Commands: python-sdk/commands.md
+      - Output & Envelopes: python-sdk/output.md
+      - Errors: python-sdk/errors.md
+      - Introspection: python-sdk/introspection.md
+  - Contributing: contributing.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/alpibrusl/acli

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -49,4 +49,4 @@ if __name__ == "__main__":
 
 ## License
 
-MIT
+[EUPL-1.2](../../LICENSE)

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -7,14 +7,14 @@ name = "acli-spec"
 version = "0.1.0"
 description = "Python SDK for the ACLI (Agent-friendly CLI) specification"
 readme = "README.md"
-license = "MIT"
+license = "EUPL-1.2"
 requires-python = ">=3.10"
 authors = [{ name = "ACLI Contributors" }]
 keywords = ["cli", "agent", "ai", "specification"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: European Union Public Licence 1.2 (EUPL 1.2)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary

- Replace MIT license with EUPL-1.2 (official EU source)
- MkDocs Material documentation site with GitHub Pages deployment
- Light/dark theme, code copy, search, navigation tabs

## Documentation pages

**Specification:** Overview, Progressive Discovery, Output Contracts, Exit Codes, Error Design, Dry-run & Idempotency, Compliance Checklist

**Python SDK:** Getting Started, ACLIApp, Commands, Output & Envelopes, Errors, Introspection

## Test plan

- [x] License file contains official EUPL-1.2 text
- [x] All license references updated
- [x] `mkdocs build --strict` passes locally
- [x] All nav links resolve
- [ ] GitHub Pages deployment succeeds after merge