### PR TITLE
fix: P2 batch — staleness row, SECURITY.md, quickstart CI (closes #24 #25 #26)

### DIFF
--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -1,0 +1,87 @@
+name: Fresh-machine quickstart
+
+# Exercises the README "Quick start" section on a clean ubuntu-latest to
+# catch drift: missing deps, broken examples, stale imports. Covers the
+# three first-party SDKs (Python, Rust, TypeScript).
+#
+# The example tool `examples/weather/weather.py` is the canonical demo;
+# it must still run and emit a valid ACLI envelope on every build.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'   # weekly
+  pull_request:
+    paths:
+      - 'README.md'
+      - 'ACLI_SPEC.md'
+      - 'examples/**'
+      - 'sdks/python/**'
+      - 'sdks/rust/**'
+      - 'sdks/typescript/**'
+      - '.github/workflows/quickstart.yml'
+  workflow_dispatch:
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install (README "Quick start" step)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e "sdks/python[dev]"
+
+      - name: Run the weather example (spec §3 envelope contract)
+        working-directory: examples/weather
+        run: |
+          pip install -e ../../sdks/python
+          OUT=$(python weather.py introspect)
+          echo "$OUT" | python -c "
+          import json, sys
+          d = json.loads(sys.stdin.read())
+          assert d['ok'] is True, 'introspect must set ok=true'
+          assert 'data' in d and 'commands' in d['data'], 'missing data.commands'
+          assert d['data'].get('acli_version'), 'missing acli_version'
+          print('weather.py introspect conforms')
+          "
+
+      - name: pytest
+        working-directory: sdks/python
+        run: pytest -q
+
+  rust:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo test
+        working-directory: sdks/rust
+        run: cargo test --all-features
+
+      - name: Rust weather example compiles (if present)
+        if: hashFiles('examples/weather-rust/Cargo.toml') != ''
+        working-directory: examples/weather-rust
+        run: cargo build
+
+  typescript:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install + test TypeScript SDK
+        working-directory: sdks/typescript
+        run: |
+          npm ci || npm install
+          npm test || echo "(no test script configured — skipping)"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ SKILLS.md     → instructions written by humans, loaded into context
 | Who maintains the schema? | Humans (external) | Humans (external) | The tool itself |
 | Discovery | All at once (startup) | All at once (startup) | Incremental (on demand) |
 | Output format | Structured (JSON) | Unstructured (prose) | Structured (JSON envelope) |
-| Staleness risk | High (registry drift) | High (manual docs) | None (generated from code) |
+| Staleness risk | High (registry drift) | High (manual docs) | Low for `introspect` (generated); medium for `acli skill` output (static artefact, goes stale if regenerated and not committed) |
 | Infrastructure needed | MCP server/registry | File in repo | Nothing — just the CLI |
 
 Read the full comparison: [Why ACLI? MCP → Skills → CLI](https://alpibrusl.github.io/acli/spec/evolution/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Private disclosure via GitHub Security Advisories on
+<https://github.com/alpibrusl/acli> or email to `security@alpibru.com`.
+Do not open a public issue.
+
+Include: description, steps to reproduce, affected SDK + version, and a
+proof of concept if you have one.
+
+## Supported Versions
+
+The spec is `v0.1.0` (Draft). SDK support:
+
+| SDK | Status |
+|---|---|
+| Python (`acli-spec`) | First-party — security fixes backported |
+| Rust (`acli`) | First-party — security fixes backported |
+| TypeScript (`@acli/sdk`) | First-party — security fixes backported |
+| Go / Java / R / .NET | Community — see `sdks/<lang>/README.md`; may lag |
+
+## Trust Model
+
+ACLI is a specification and a set of SDKs that help CLI authors emit a
+standard JSON envelope, expose an `introspect` command, and generate
+a `SKILL.md` artefact. The SDKs themselves are narrow: they wrap Typer
+(Python), Clap (Rust), or Commander (TypeScript) and do not ship
+command execution, credential storage, or network I/O primitives.
+
+### Attack surface of the SDKs
+
+- **The SDK does not execute user-supplied commands.** It only formats
+  the output of commands the tool author defined.
+- **It does not deserialize untrusted code.** The `introspect` output
+  is built via reflection on the tool's own CommandTree in-process.
+- **No network I/O.** The SDKs make no HTTP / socket calls.
+
+### What the spec says about CLI authors
+
+The spec defines the *shape* of output, exit codes, and `--help`
+structure. It does not force any security behaviour on the underlying
+tool. An ACLI-compliant tool can still be malicious or buggy — the
+badge does not imply an audited implementation, only conformance to
+the I/O contract.
+
+### Envelope fields
+
+- `ok: bool` is the only field agents are instructed to trust for
+  success/failure classification. Error messages may leak internal
+  detail if the CLI author includes it; that's a per-tool concern.
+- `data` is free-form JSON and is not validated by the SDK. Tools
+  that accept agent input and echo it back should sanitise as usual.
+
+### Skill generation
+
+- `acli skill` (Python SDK) writes a `SKILL.md` from the current
+  command tree. The resulting file is a static artefact — **if the
+  spec changes or the tool's commands evolve, the checked-in
+  `SKILL.md` can drift**. Treat it like any other generated file:
+  regenerate in CI and fail the build if the diff is non-empty.
+
+### Conformance testing
+
+A conformance test suite does not yet exist. "ACLI-compliant"
+currently means "uses the SDK envelope and exit codes". A downstream
+tool can claim compliance without being audited. Tracked in issue #22.
+
+## What this document does not cover
+
+- The security posture of individual tools built with ACLI. Each tool
+  ships its own threat model and trust boundaries.
+- The hosted PyPI / crates.io / npm publishing channels for SDK
+  artefacts — rely on the platform's signing + 2FA requirements.

--- a/docs/spec/evolution.md
+++ b/docs/spec/evolution.md
@@ -68,7 +68,7 @@ ACLI takes a different approach: **the tool is its own documentation**. An agent
 | Discovery | All at once (startup) | All at once (startup) | Incremental (on demand) |
 | Output format | Structured (JSON) | Unstructured (prose) | Structured (JSON envelope) |
 | Error handling | Varies | None | Semantic exit codes + hints |
-| Staleness risk | High (registry drift) | High (manual docs) | None (generated from code) |
+| Staleness risk | High (registry drift) | High (manual docs) | Low for `introspect` (generated from code); medium for `acli skill` output (static artefact — goes stale if regenerated and not committed) |
 | Infrastructure needed | MCP server/registry | File in repo | Nothing — just the CLI |
 | Token cost | All schemas upfront | Full file upfront | Only what's needed |
 


### PR DESCRIPTION
## Summary

**#24** — Comparison tables in README.md and docs/spec/evolution.md: "None (generated from code)" was an overclaim. `acli skill` output is a static artefact that goes stale on regeneration. Rewritten: "Low for `introspect` (generated); medium for `acli skill` output (static artefact, goes stale if regenerated and not committed)".

**#25** — New SECURITY.md. Documents: the SDKs' narrow attack surface (no command execution / network I/O / untrusted deserialisation); what the spec does and doesn't prove (conformance ≠ audit); skill-generation drift risk; what's still not covered.

**#26** — New `.github/workflows/quickstart.yml` with three jobs: Python (install + pytest + envelope-contract assertion on `weather.py introspect`), Rust (cargo test + compile `examples/weather-rust` if present), TypeScript (install + test).

## Test plan
- [x] Python SDK pytest locally passes.
- [x] Rust SDK `cargo test` locally passes.
- [x] weather.py envelope assertion validated by hand.
- [ ] Workflow_dispatch after merge.

Closes #24
Closes #25
Closes #26