### PR TITLE
release: v0.5.0 — SKILL.md (agentskills.io) migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-04-23
+
 ### Changed (breaking)
 
 - **All SDKs**: the `skill` subcommand now emits `SKILL.md` (singular) with
@@ -107,7 +109,8 @@ new file directly.
 - CI pipeline with Python 3.10–3.13 matrix
 - Release pipeline with PyPI Trusted Publishing
 
-[Unreleased]: https://github.com/alpibrusl/acli/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/alpibrusl/acli/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/alpibrusl/acli/compare/v0.4.1...v0.5.0
 [0.4.0]: https://github.com/alpibrusl/acli/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/alpibrusl/acli/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/alpibrusl/acli/compare/v0.1.4...v0.2.0

--- a/sdks/dotnet/Acli.Spec/Acli.Spec.csproj
+++ b/sdks/dotnet/Acli.Spec/Acli.Spec.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <RootNamespace>Acli</RootNamespace>
     <AssemblyName>Acli.Spec</AssemblyName>
-    <Version>0.3.0</Version>
+    <Version>0.5.0</Version>
     <PackageId>Acli.Spec</PackageId>
     <Description>.NET SDK for the ACLI (Agent-friendly CLI) specification</Description>
     <Authors>ACLI Contributors</Authors>

--- a/sdks/java/pom.xml
+++ b/sdks/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.acli</groupId>
     <artifactId>acli-spec</artifactId>
-    <version>0.4.0</version>
+    <version>0.5.0</version>
     <packaging>jar</packaging>
 
     <name>ACLI Java SDK</name>

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "acli-spec"
-version = "0.4.1"
+version = "0.5.0"
 description = "Python SDK for the ACLI (Agent-friendly CLI) specification"
 readme = "README.md"
 license = "EUPL-1.2"

--- a/sdks/python/src/acli/__init__.py
+++ b/sdks/python/src/acli/__init__.py
@@ -51,4 +51,4 @@ __all__ = [
     "suggest_flag",
 ]
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"

--- a/sdks/r/DESCRIPTION
+++ b/sdks/r/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: acli.spec
 Title: Agent-Friendly Command Line Interface (ACLI) Specification
-Version: 0.3.0
+Version: 0.5.0
 Author: ACLI Contributors
 Maintainer: ACLI Contributors <acli-spec@noreply.invalid>
 Description: Reference implementation of the ACLI v0.1.0 specification: JSON

--- a/sdks/rust/Cargo.lock
+++ b/sdks/rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "serde",

--- a/sdks/rust/Cargo.toml
+++ b/sdks/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acli"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Rust SDK for the ACLI (Agent-friendly CLI) specification"
 license = "EUPL-1.2"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@acli/sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "TypeScript SDK for the ACLI (Agent-friendly CLI) specification",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Version bump across all SDKs to **v0.5.0** — the SKILL.md (agentskills.io) migration merged in #30 is a breaking change and ships as a minor version bump per the pre-1.0 stability policy.

| SDK | Old | New | Publishes on tag |
|---|---|---|---|
| Python | 0.4.1 | **0.5.0** | → PyPI (Trusted Publishing) |
| Rust | 0.4.0 | **0.5.0** | → crates.io |
| TypeScript | 0.4.0 | **0.5.0** | → npm (with provenance) |
| Java | 0.4.0 | **0.5.0** | — (not automated) |
| .NET | 0.3.0 | **0.5.0** | — (not automated) |
| R | 0.3.0 | **0.5.0** | — (not automated) |

`CHANGELOG.md`: `[Unreleased]` section promoted to `[0.5.0] - 2026-04-23` with the full breaking-change entry and the user-facing migration recipe reviewed in #30.

## Release plan

1. Merge this PR.
2. Tag the merge commit on `main` with `v0.5.0` and push the tag — `.github/workflows/release.yml` runs and publishes Python → PyPI, Rust → crates.io, TypeScript → npm, then creates a GitHub Release with notes extracted from `CHANGELOG.md`'s `[0.5.0]` section.

## Test plan

- [x] Python 137 tests pass with `version = "0.5.0"` and `__version__ = "0.5.0"`.
- [x] Rust 47 tests pass with `version = "0.5.0"`.
- [x] TypeScript 34 tests pass with `"version": "0.5.0"`.
- [ ] CI confirms same on this branch.
- [ ] After merge + tag: PyPI, crates.io, npm show 0.5.0 published and a GitHub Release v0.5.0 exists with the `[0.5.0]` changelog body.

## Related

- Implementation PR: #30 (merged to main)
- Follow-up issues: #31, #32, #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)