### PR TITLE
chore(ci): clear pre-existing lint failures (fixes #33)

### DIFF
--- a/sdks/python/src/acli/__init__.py
+++ b/sdks/python/src/acli/__init__.py
@@ -9,7 +9,7 @@ from acli.errors import (
     NotFoundError,
     PermissionDeniedError,
     PreconditionError,
-    TimeoutError,
+    TimeoutError,  # noqa: A004 — spec §3 TIMEOUT exit code; shadowing is intentional
     UpstreamError,
     suggest_flag,
 )
@@ -31,12 +31,12 @@ __all__ = [
     "CacheMeta",
     "CommandExample",
     "CommandMeta",
-    "ParamVersionMeta",
     "ConflictError",
     "ExitCode",
     "InvalidArgsError",
     "NotFoundError",
     "OutputFormat",
+    "ParamVersionMeta",
     "PermissionDeniedError",
     "PreconditionError",
     "TimeoutError",

--- a/sdks/python/src/acli/errors.py
+++ b/sdks/python/src/acli/errors.py
@@ -39,9 +39,7 @@ class InvalidArgsError(ACLIError):
         hints: list[str] | None = None,
         docs: str | None = None,
     ) -> None:
-        super().__init__(
-            message, code=ExitCode.INVALID_ARGS, hint=hint, hints=hints, docs=docs
-        )
+        super().__init__(message, code=ExitCode.INVALID_ARGS, hint=hint, hints=hints, docs=docs)
 
 
 class NotFoundError(ACLIError):
@@ -104,9 +102,7 @@ class UpstreamError(ACLIError):
         hints: list[str] | None = None,
         docs: str | None = None,
     ) -> None:
-        super().__init__(
-            message, code=ExitCode.UPSTREAM_ERROR, hint=hint, hints=hints, docs=docs
-        )
+        super().__init__(message, code=ExitCode.UPSTREAM_ERROR, hint=hint, hints=hints, docs=docs)
 
 
 class TimeoutError(ACLIError):  # noqa: A001 — intentionally shadows builtin
@@ -124,9 +120,7 @@ class TimeoutError(ACLIError):  # noqa: A001 — intentionally shadows builtin
         hints: list[str] | None = None,
         docs: str | None = None,
     ) -> None:
-        super().__init__(
-            message, code=ExitCode.TIMEOUT, hint=hint, hints=hints, docs=docs
-        )
+        super().__init__(message, code=ExitCode.TIMEOUT, hint=hint, hints=hints, docs=docs)
 
 
 class PermissionDeniedError(ACLIError):

--- a/sdks/python/src/acli/skill.py
+++ b/sdks/python/src/acli/skill.py
@@ -45,7 +45,27 @@ def _one_line(value: str) -> str:
 
 
 # YAML indicators that, when a scalar starts with them, require quoting.
-_YAML_RESERVED_START = ("!", "&", "*", "?", "|", ">", "'", '"', "%", "@", "`", "#", ",", "[", "]", "{", "}", "-", ":")
+_YAML_RESERVED_START = (
+    "!",
+    "&",
+    "*",
+    "?",
+    "|",
+    ">",
+    "'",
+    '"',
+    "%",
+    "@",
+    "`",
+    "#",
+    ",",
+    "[",
+    "]",
+    "{",
+    "}",
+    "-",
+    ":",
+)
 
 
 def _yaml_scalar(value: str) -> str:

--- a/sdks/python/tests/test_skill.py
+++ b/sdks/python/tests/test_skill.py
@@ -221,7 +221,7 @@ class TestGenerateSkill:
         assert 'when_to_use: "has # and : both"' in content
 
     def test_frontmatter_escapes_backslash_in_quoted(self) -> None:
-        content = generate_skill(_sample_tree(), description='a: b has \\ backslash')
+        content = generate_skill(_sample_tree(), description="a: b has \\ backslash")
         # Triggers quoting (contains ": "); backslash must be doubled.
         assert 'description: "a: b has \\\\ backslash"' in content
 

--- a/sdks/rust/src/output.rs
+++ b/sdks/rust/src/output.rs
@@ -138,6 +138,12 @@ pub fn dry_run_envelope(
 }
 
 /// Build an error envelope using a typed ExitCode.
+///
+/// The argument count reflects the required shape of the ACLI error envelope
+/// (spec §2.2: `command`, `code`, `message`, `hint`, `hints`, `docs`, `version`,
+/// plus timing). Grouping these into a struct would hide the spec alignment;
+/// the lint is silenced deliberately.
+#[allow(clippy::too_many_arguments)]
 pub fn error_envelope(
     command: &str,
     code: ExitCode,
@@ -148,10 +154,23 @@ pub fn error_envelope(
     version: &str,
     start: Option<Instant>,
 ) -> Envelope {
-    error_envelope_raw(command, code.name(), message, hint, hints, docs, version, start)
+    error_envelope_raw(
+        command,
+        code.name(),
+        message,
+        hint,
+        hints,
+        docs,
+        version,
+        start,
+    )
 }
 
 /// Build an error envelope from a raw code string.
+///
+/// See `error_envelope` — the argument shape mirrors the spec's error envelope
+/// fields, so the `too_many_arguments` lint is allowed here.
+#[allow(clippy::too_many_arguments)]
 pub fn error_envelope_raw(
     command: &str,
     code: &str,

--- a/sdks/rust/src/skill.rs
+++ b/sdks/rust/src/skill.rs
@@ -47,7 +47,11 @@ fn default_description(name: &str, user_commands: &[&crate::introspect::CommandI
     if user_commands.is_empty() {
         return format!("Invoke the `{name}` CLI.");
     }
-    let shown: Vec<&str> = user_commands.iter().take(4).map(|c| c.name.as_str()).collect();
+    let shown: Vec<&str> = user_commands
+        .iter()
+        .take(4)
+        .map(|c| c.name.as_str())
+        .collect();
     let suffix = if user_commands.len() > 4 { "…" } else { "" };
     format!(
         "Invoke the `{name}` CLI. Commands: {}{suffix}",

--- a/sdks/rust/tests/integration_test.rs
+++ b/sdks/rust/tests/integration_test.rs
@@ -134,13 +134,7 @@ fn test_success_envelope_cache_meta() {
         key: Some("sha256:abc".into()),
         age_seconds: Some(3600),
     };
-    let env = success_envelope(
-        "run",
-        json!({"x": 1}),
-        "1.0.0",
-        None,
-        Some(cache.clone()),
-    );
+    let env = success_envelope("run", json!({"x": 1}), "1.0.0", None, Some(cache.clone()));
     assert_eq!(env.meta.cache, Some(cache));
 }
 


### PR DESCRIPTION
## Summary

Closes #33. Small, narrow-scope housekeeping to turn `main`'s CI green.

### Rust (`sdks/rust/src/output.rs`)

Add `#[allow(clippy::too_many_arguments)]` on `error_envelope` and `error_envelope_raw`. The argument count mirrors the required shape of the ACLI error envelope (spec §2.2: `command`, `code`, `message`, `hint`, `hints`, `docs`, `version`, plus timing). Collapsing these into a struct would hide the spec alignment — the lint is silenced deliberately and each function now has a docstring explaining why. `cargo fmt` also reflowed the forwarding call site in `error_envelope` and a couple of long lines in `skill.rs` / `integration_test.rs`.

### Python (`sdks/python/src/acli/__init__.py`)

- `A004`: `from acli.errors import TimeoutError` shadows Python's built-in, but the ACLI `TimeoutError` is the spec §3 TIMEOUT exit code re-export and the shadowing is intentional. Added `# noqa: A004` with a comment pointing at the spec.
- `RUF022`: sorted `__all__` isort-style. No behavioural change.
- `ruff format` reflowed the `_YAML_RESERVED_START` tuple in `skill.py` (E501 — the `:` added in PR #30 round 2 pushed the single-line form over 99 chars), plus one line in `test_skill.py`.

## Test plan

- [x] `ruff check src/ tests/` — clean.
- [x] `ruff format --check src/ tests/` — clean.
- [x] `pytest` — 137 pass, 96% coverage.
- [x] `cargo clippy --tests -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo test` — 47 pass.
- [ ] CI on this branch goes green (previously `Python SDK (3.10)` and `Rust SDK` failed with exactly the lints addressed here).

## Follow-ups

After this lands, I'll rebase #34 (release v0.5.0) so the release ships with fully green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)